### PR TITLE
remove jade in the package.json if template engine isn't jade

### DIFF
--- a/bin/koa
+++ b/bin/koa
@@ -194,7 +194,6 @@ function createApplication(app_name, path) {
       , dependencies: {
           "co": "^4.6.0",
           "debug": "^2.2.0",
-          "jade": "^1.11.0",
           "koa": "^1.1.2",
           "koa-bodyparser": "^2.0.1",
           "koa-json": "^1.1.1",

--- a/bin/koa2
+++ b/bin/koa2
@@ -200,7 +200,6 @@ function createApplication(app_name, path) {
       , "dependencies": {
         "co": "^4.6.0",
         "debug": "^2.2.0",
-        "jade": "~1.11.0",
         "koa": "^2.0.0",
         "koa-bodyparser": "^2.0.1",
         "koa-convert": "^1.2.0",


### PR DESCRIPTION
`jade` should not be added in `package.json` if i use `koa(2) -e foo`.